### PR TITLE
Prebuilt OpenSSL binaries.

### DIFF
--- a/openssl/README.md
+++ b/openssl/README.md
@@ -1,0 +1,9 @@
+# OpenSSL
+
+Prepackaged binaries built using the instructions at
+https://github.com/ripple/rippled/tree/develop/Builds/VisualStudio2015#install-openssl
+
+* `openssl-1.0.2d.zip`
+  * Built using and for Visual Studio 2015.
+  * To use as a drop-in replacement for the build instructions, unzip
+    the file contents to `C:\lib`.


### PR DESCRIPTION
The libraries built here are 64-bit static release libraries. Debug symbols are provided in the `lib.pdb` in the same folder.
